### PR TITLE
feat: enable manual token entry

### DIFF
--- a/default.noauth.toml
+++ b/default.noauth.toml
@@ -7,3 +7,7 @@ family_name = "Edwards"
 email = "alice@example.com"
 preferred_username = "alice"
 roles = ["admin"]
+
+[noauth.token]
+aud = "client_id"
+scope = "demo"

--- a/noauth/config.py
+++ b/noauth/config.py
@@ -3,7 +3,7 @@
 from os import getenv
 from pathlib import Path
 import tomllib
-from typing import Any, Dict, Union
+from typing import Any, Dict, Optional, Union
 
 from pydantic import BaseModel, ValidationError
 
@@ -29,6 +29,7 @@ class NoAuthConfig(BaseModel):
     passphrase: str
     oidc: OIDCConfig
     default: Dict[str, Any]
+    token: Optional[Dict[str, Any]] = None
 
     @classmethod
     def load(cls, path: Union[str, Path, None] = None) -> "NoAuthConfig":
@@ -44,7 +45,6 @@ class NoAuthConfig(BaseModel):
         if path.exists():
             with open(path, "rb") as f:
                 table = tomllib.load(f)
-            print(table)
 
             config.update(table.get("noauth", {}))
 

--- a/noauth/dependencies.py
+++ b/noauth/dependencies.py
@@ -9,6 +9,7 @@ from noauth.config import NoAuthConfig
 
 Store: ContextVar[AStore] = ContextVar("Store")
 default_user: ContextVar[dict] = ContextVar("default_user")
+default_token: ContextVar[dict] = ContextVar("default_token")
 Config: ContextVar[NoAuthConfig] = ContextVar("Config")
 
 context = Context()
@@ -29,6 +30,7 @@ def setup(
     store: AStore,
     config: NoAuthConfig,
     user: dict,
+    token: dict,
 ):
     """Setup context."""
 
@@ -36,5 +38,6 @@ def setup(
         Store.set(store)
         Config.set(config)
         default_user.set(user)
+        default_token.set(token)
 
     context.run(_setup)

--- a/noauth/main.py
+++ b/noauth/main.py
@@ -12,7 +12,8 @@ from fastapi.staticfiles import StaticFiles
 from noauth.config import NoAuthConfig
 from noauth.dependencies import setup
 
-from . import oidc
+from noauth import oidc
+from noauth import manual
 
 ACAPY = getenv("ACAPY", "http://localhost:3001")
 
@@ -35,7 +36,7 @@ async def init_deps(app: FastAPI):
             key = Key.generate(KeyAlg.ED25519)
             await session.insert_key("jwt", key)
 
-    setup(store, config, config.default)
+    setup(store, config, config.default, config.token or {})
 
     try:
         yield
@@ -46,4 +47,5 @@ async def init_deps(app: FastAPI):
 app = FastAPI(lifespan=init_deps)
 
 app.include_router(oidc.router)
+app.include_router(manual.router)
 app.mount("/", StaticFiles(directory="static"), name="static")

--- a/noauth/manual.py
+++ b/noauth/manual.py
@@ -1,0 +1,106 @@
+"""Retrieving a token."""
+
+import json
+import logging
+from time import time
+from typing import cast
+from uuid import uuid4
+
+from aries_askar import Key, Store as AStore
+from fastapi import APIRouter, Depends, Form, HTTPException, Request
+from fastapi.responses import HTMLResponse, RedirectResponse
+
+from noauth import jwt
+from noauth.config import NoAuthConfig
+from noauth.oidc import url_with_query
+from noauth.templates import templates
+from noauth.dependencies import Config, Store, get, default_token
+
+router = APIRouter(prefix="/manual")
+LOGGER = logging.getLogger("uvicorn.error." + __name__)
+
+
+@router.get("/token", response_class=HTMLResponse)
+async def manual_token(
+    request: Request,
+    default_token: dict = Depends(get(default_token)),
+):
+    """Generate a token."""
+    query = request.query_params
+    claims = dict(query)
+    return templates.TemplateResponse(
+        request=request,
+        name="token_entry.html",
+        context={"default": {**default_token, **claims}},
+    )
+
+
+@router.post("/token")
+async def post_manual_token_and_redirect(
+    claims: str = Form(),
+    valid_for: str = Form(),
+    store: AStore = Depends(get(Store)),
+    config: NoAuthConfig = Depends(get(Config)),
+):
+    """Submit token form and get signed token."""
+    try:
+        parsed_claims = json.loads(claims)
+    except json.JSONDecodeError:
+        raise HTTPException(400, "Invalid claims")
+
+    valid = int(valid_for)
+
+    async with store.session() as session:
+        key_entry = await session.fetch_key("jwt")
+        if not key_entry:
+            LOGGER.error("key missing")
+            raise HTTPException(500)
+        key = cast(Key, key_entry.key)
+
+    now = int(time())
+
+    token = jwt.sign(
+        headers={
+            "alg": "EdDSA",
+            "kid": key.get_jwk_thumbprint(),
+        },
+        payload={
+            "exp": now + valid,
+            "iat": now,
+            "jti": str(uuid4()),
+            "iss": config.oidc.issuer,
+            **parsed_claims,
+        },
+        key=key,
+    )
+    return RedirectResponse(
+        url_with_query("/manual/token/complete", token=token, **parsed_claims),
+        status_code=303,
+    )
+
+
+@router.get("/token/complete", response_class=HTMLResponse)
+async def manual_token_complete(
+    request: Request,
+    token: str,
+):
+    """Display token."""
+    query = request.query_params
+    claims = dict(query)
+    del claims["token"]
+
+    enc_headers, enc_payload, sig = token.split(".")
+    headers = json.loads(jwt.base64_urldecode_no_padding(enc_headers))
+    payload = json.loads(jwt.base64_urldecode_no_padding(enc_payload))
+    token_value = "\n.\n".join(
+        [json.dumps(headers, indent=2), json.dumps(payload, indent=2), sig]
+    )
+    return templates.TemplateResponse(
+        request=request,
+        name="token_complete.html",
+        context={
+            "token": token,
+            "token_value": token_value,
+            "new": url_with_query("/manual/token", **claims),
+        },
+    )

--- a/noauth/oidc.py
+++ b/noauth/oidc.py
@@ -145,7 +145,6 @@ async def authorize(
             value_json=oidc.serialize(),
         )
 
-    print(default_user)
     return templates.TemplateResponse(
         request=request,
         name="id_entry.html",

--- a/noauth/templates/copy_button.html
+++ b/noauth/templates/copy_button.html
@@ -1,0 +1,43 @@
+{% macro copy(target_id) %}
+<style>
+button.copy {
+    padding: 8px 12px;
+    background-color: var(--light-gray);
+    color: var(--mid-dark-gray);
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 16px;
+}
+
+button.copy:hover {
+    background-color: var(--mid-dark-gray);
+    color: var(--white);
+}
+
+button.copy.clicked {
+    background-color: var(--light-blue);
+    color: var(--white);
+}
+button.copy.clicked:hover {
+    background-color: var(--light-blue);
+    color: var(--white);
+}
+[x-cloak] { display: none !important; }
+</style>
+
+<button
+  x-cloak
+  x-data="{ clicked: false }"
+  class="copy"
+  :class="clicked ? 'clicked' : ''"
+  @click="
+    const copyText = document.getElementById('{{target_id}}');
+    navigator.clipboard.writeText(copyText.value)
+      .catch(err => console.error('Error in copying text: ', err));
+   clicked = true; setTimeout(() => clicked = false, 1000);
+   ">
+  <i x-show="!clicked" class="fa-solid fa-copy"></i>
+  <i x-show="clicked" class="fa-solid fa-check"></i>
+</button>
+{% endmacro %}

--- a/noauth/templates/token_complete.html
+++ b/noauth/templates/token_complete.html
@@ -1,0 +1,30 @@
+{% extends 'public.html' %}
+{% from "copy_button.html" import copy %}
+
+{% block title %}Token{% endblock %}
+
+{% block head %}
+<link rel="stylesheet" href="{{ url_for('static', path='/token.css') }}">
+<script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"></script>
+{% endblock %}
+
+{% block content %}
+<div class="service-container">
+  <h2>Token</h2>
+  <p>Below is the generated token and its decoded value.</p>
+  <div class="info-section">
+    <label for="token">Token</label>
+    <div class="info">
+      <input type="text" id="token" value="{{token}}" readonly>
+      {{copy("token")}}
+    </div>
+  </div>
+  <div class="info-section">
+    <label for="value">Value</label>
+    <textarea id="value" readonly>{{token_value}}</textarea>
+  </div>
+  <div class="info-section">
+    <a class="btn-submit" href="{{new}}">New Token</a>
+  </div>
+</div>
+{% endblock %}

--- a/noauth/templates/token_entry.html
+++ b/noauth/templates/token_entry.html
@@ -1,0 +1,52 @@
+{% extends 'public.html' %}
+
+{% block title %}User Info{% endblock %}
+
+{% block head %}
+<link rel="stylesheet" href="{{ url_for('static', path='/user_info.css') }}">
+{% endblock %}
+
+{% block content %}
+<div class="form-container">
+    <h2>Token Info</h2>
+    <p>Please fill out the form below to populate the Access Token.</p>
+    <div class="warning">
+      <i class="fa-solid fa-circle-exclamation"></i>
+      This is for demonstration purposes only.
+      <br />
+      Never use this service in production.
+    </div>
+    <form id="claimform" action="{{ url_for('post_manual_token_and_redirect') }}" method="POST">
+      <div id="jsoneditor"></div>
+      <input type="hidden" name="claims" id="claims">
+      <div class="form-group">
+        <label for="valid-for">Valid For</label>
+        <input type="number" id="valid-for" name="valid_for" placeholder="How long the token should be valid for" value=300 required>
+      </div>
+      <div class="controls">
+        <button type="submit" class="btn-submit">Submit</button>
+      </div>
+    </form>
+
+    <script>
+      // Create the editor
+      const container = document.getElementById("jsoneditor");
+      const options = {
+        mode: "code",
+        modes: ["tree", "code"]
+      };
+      const editor = new JSONEditor(container, options);
+
+      // Set initial JSON
+      const initialJson = {{ default | tojson }};
+      editor.set(initialJson);
+
+      // Handle form submission
+      const form = document.getElementById("claimform");
+      form.addEventListener('submit', function(event) {
+        const updatedJson = editor.get();
+        document.getElementById("claims").value = JSON.stringify(updatedJson);
+      });
+    </script>
+</div>
+{% endblock %}

--- a/static/public.css
+++ b/static/public.css
@@ -24,7 +24,7 @@ body, h1, p, ul, li, nav, main, footer {
   --white: #FCFCFC;
 }
 
-h2, p, button {
+h2, p, button, input, a, label {
   font-family: Open Sans, sans-serif;
 }
 

--- a/static/token.css
+++ b/static/token.css
@@ -1,0 +1,78 @@
+.service-container {
+    background-color: var(--white);
+    padding: 40px;
+    width: 600px;
+    max-width: 600px;
+    margin: 50px auto;
+    box-shadow: 0 4px 8px rgba(0,0,0,0.1);
+    border-radius: 8px;
+}
+
+.service-container p {
+  text-align: center;
+  color: var(--mid-dark-gray);
+  margin-bottom: 30px;
+}
+
+h2 {
+    text-align: center;
+    color: var(--dark-gray);
+    margin-bottom: 20px;
+}
+
+.info-section {
+    margin-bottom: 20px;
+}
+
+.info-section p {
+    color: var(--mid-dark-gray);
+}
+
+label {
+    display: block;
+    margin-bottom: 5px;
+    color: var(--mid-dark-gray);
+}
+
+.info {
+    display: flex;
+    align-items: center;
+    background-color: var(--light-gray);
+    border-radius: 8px;
+    padding: .5rem;
+}
+
+input[type="text"], textarea {
+    flex-grow: 1;
+    padding: 10px;
+    border: 0;
+    margin-right: 10px;
+    background-color: var(--light-gray);
+    font-size: 14px;
+}
+input[type="text"]:focus-visible, textarea:focus-visible {
+  outline: none;
+}
+
+textarea {
+    height: 220px;
+    resize: none;
+    width: 100%;
+    box-sizing: border-box;
+}
+
+.btn-submit {
+    width: 100%;
+    padding: 10px;
+    background-color: var(--dark-gray);
+    color: white;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 16px;
+    text-decoration: none;
+}
+
+.btn-submit:hover {
+    background-color: var(--mid-dark-gray);
+}

--- a/static/user_info.css
+++ b/static/user_info.css
@@ -18,8 +18,25 @@
   margin-bottom: 30px;
 }
 
+.form-group {
+    margin-bottom: 20px;
+}
+
+.form-group label {
+    display: block;
+    margin-bottom: 5px;
+    color: var(--dark-gray);
+}
+
+.form-group input[type="number"] {
+    width: 100%;
+    padding: 10px;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    box-sizing: border-box;
+}
+
 .controls {
-  margin-top: 20px;
   display: flex;
   flex-direction: row;
 }
@@ -58,4 +75,5 @@
 #jsoneditor {
   min-height: 300px;
   height: 40vh;
+  margin-bottom: 20px;
 }


### PR DESCRIPTION
This change enables manually entering the claims to be issued in a token. The token is then presented for copying. This is not an OAuth 2.0 flow.

The endpoint is `/manual/token`.