### PR TITLE
New features and optimizations

### DIFF
--- a/demo/demo.noauth.toml
+++ b/demo/demo.noauth.toml
@@ -2,8 +2,8 @@
 issuer = "http://noauth"
 
 [noauth.client]
-client_id = "example"
-client_secret = "supersecret"
+client_id = "wordpress"
+client_secret = "asdfasdfasdf"
 id_token_signed_response_alg = "ES256"
 
 [noauth.default]

--- a/demo/docker-compose.yml
+++ b/demo/docker-compose.yml
@@ -11,9 +11,7 @@ services:
     volumes:
       - "../noauth:/usr/src/app/noauth:z"
       - "../static:/usr/src/app/static:z"
-    environment:
-      NOAUTH_ISSUER: http://noauth
-      NOAUTH_PASSPHRASE: insecure
+      - "./demo.noauth.toml:/usr/src/app/noauth.toml:z"
     healthcheck:
       test: python healthcheck.py localhost 80
       start_period: 10s

--- a/noauth/dependencies.py
+++ b/noauth/dependencies.py
@@ -1,43 +1,67 @@
 """Common dependencies."""
 
-from contextvars import Context, ContextVar
-from typing import Callable, TypeVar, cast
-from aries_askar import Store as AStore
+from contextlib import asynccontextmanager
+from pathlib import Path
+from aries_askar import Key, KeyAlg, Store as AStore
+from fastapi import FastAPI
 
 from noauth.config import NoAuthConfig
 
 
-Store: ContextVar[AStore] = ContextVar("Store")
-default_user: ContextVar[dict] = ContextVar("default_user")
-default_token: ContextVar[dict] = ContextVar("default_token")
-Config: ContextVar[NoAuthConfig] = ContextVar("Config")
-
-context = Context()
-
-T = TypeVar("T")
+_store: AStore
+_default_user: dict
+_default_token: dict
+_config: NoAuthConfig
 
 
-def get(var: ContextVar[T]) -> Callable[[], T]:
-    """Get a context var as a dependency."""
-
-    def _get():
-        return context.get(var)
-
-    return cast(Callable[[], T], _get)
+def store() -> AStore:
+    """Return store."""
+    global _store
+    return _store
 
 
-def setup(
-    store: AStore,
-    config: NoAuthConfig,
-    user: dict,
-    token: dict,
-):
+def default_user() -> dict:
+    """Return default_user."""
+    global _default_user
+    return _default_user
+
+
+def default_token() -> dict:
+    """Return default_token."""
+    global _default_token
+    return _default_token
+
+
+def config() -> NoAuthConfig:
+    """Return config."""
+    global _config
+    return _config
+
+
+@asynccontextmanager
+async def setup(app: FastAPI):
     """Setup context."""
+    global _store
+    global _default_user
+    global _default_token
+    global _config
+    _config = NoAuthConfig.load("./noauth.toml")
+    store_path = Path("/var/lib/noauth/store.db")
+    store_path.parent.mkdir(parents=True, exist_ok=True)
+    _store = await AStore.provision(
+        f"sqlite://{store_path}", "kdf:argon2i", _config.passphrase
+    )
 
-    def _setup():
-        Store.set(store)
-        Config.set(config)
-        default_user.set(user)
-        default_token.set(token)
+    async with _store.session() as session:
+        key_entry = await session.fetch_key("jwt")
+        if not key_entry:
+            key = Key.generate(KeyAlg.ED25519)
+            await session.insert_key("jwt", key)
 
-    context.run(_setup)
+    _default_user = _config.default
+    _default_token = _config.token or {}
+
+    try:
+        yield
+    finally:
+        await _store.close()

--- a/noauth/dependencies.py
+++ b/noauth/dependencies.py
@@ -2,19 +2,21 @@
 
 from contextlib import asynccontextmanager
 from pathlib import Path
-from aries_askar import Key, KeyAlg, Store as AStore
+from aries_askar import Key, KeyAlg
 from fastapi import FastAPI
 
 from noauth.config import NoAuthConfig
+from noauth.store import TemporalKVStore
 
 
-_store: AStore
+_store: TemporalKVStore
 _default_user: dict
 _default_token: dict
 _config: NoAuthConfig
+_key: Key
 
 
-def store() -> AStore:
+def store() -> TemporalKVStore:
     """Return store."""
     global _store
     return _store
@@ -38,6 +40,12 @@ def config() -> NoAuthConfig:
     return _config
 
 
+def key() -> Key:
+    """Return key."""
+    global _key
+    return _key
+
+
 @asynccontextmanager
 async def setup(app: FastAPI):
     """Setup context."""
@@ -45,18 +53,14 @@ async def setup(app: FastAPI):
     global _default_user
     global _default_token
     global _config
+    global _key
+
     _config = NoAuthConfig.load("./noauth.toml")
     store_path = Path("/var/lib/noauth/store.db")
     store_path.parent.mkdir(parents=True, exist_ok=True)
-    _store = await AStore.provision(
-        f"sqlite://{store_path}", "kdf:argon2i", _config.passphrase
-    )
+    _store = await TemporalKVStore().open()
 
-    async with _store.session() as session:
-        key_entry = await session.fetch_key("jwt")
-        if not key_entry:
-            key = Key.generate(KeyAlg.ED25519)
-            await session.insert_key("jwt", key)
+    _key = Key.generate(KeyAlg.ED25519)
 
     _default_user = _config.default
     _default_token = _config.token or {}

--- a/noauth/dependencies.py
+++ b/noauth/dependencies.py
@@ -1,12 +1,16 @@
 """Common dependencies."""
 
 from contextlib import asynccontextmanager
+import logging
 from pathlib import Path
 from aries_askar import Key, KeyAlg
 from fastapi import FastAPI
 
 from noauth.config import NoAuthConfig
 from noauth.store import TemporalKVStore
+
+
+LOGGER = logging.getLogger(__name__)
 
 
 _store: TemporalKVStore
@@ -60,7 +64,13 @@ async def setup(app: FastAPI):
     store_path.parent.mkdir(parents=True, exist_ok=True)
     _store = await TemporalKVStore().open()
 
-    _key = Key.generate(KeyAlg.ED25519)
+    LOGGER.debug(
+        "id_token_signed_response_alg: %s", _config.client.id_token_signed_response_alg
+    )
+    if _config.client.id_token_signed_response_alg == "ES256":
+        _key = Key.generate(KeyAlg.P256)
+    else:
+        _key = Key.generate(KeyAlg.ED25519)
 
     _default_user = _config.default
     _default_token = _config.token or {}

--- a/noauth/main.py
+++ b/noauth/main.py
@@ -1,15 +1,11 @@
 """NoAuth."""
 
-from contextlib import asynccontextmanager
 import logging
 from os import getenv
-from pathlib import Path
 
-from aries_askar import Key, KeyAlg, Store as AStore
 from fastapi import FastAPI
 from fastapi.staticfiles import StaticFiles
 
-from noauth.config import NoAuthConfig
 from noauth.dependencies import setup
 
 from noauth import oidc
@@ -20,31 +16,7 @@ ACAPY = getenv("ACAPY", "http://localhost:3001")
 logging.getLogger("uvicorn.error").setLevel(logging.DEBUG)
 
 
-@asynccontextmanager
-async def init_deps(app: FastAPI):
-    """Test connectivity to ACA-Py."""
-    config = NoAuthConfig.load("./noauth.toml")
-    store_path = Path("/var/lib/noauth/store.db")
-    store_path.parent.mkdir(parents=True, exist_ok=True)
-    store = await AStore.provision(
-        f"sqlite://{store_path}", "kdf:argon2i", config.passphrase
-    )
-
-    async with store.session() as session:
-        key_entry = await session.fetch_key("jwt")
-        if not key_entry:
-            key = Key.generate(KeyAlg.ED25519)
-            await session.insert_key("jwt", key)
-
-    setup(store, config, config.default, config.token or {})
-
-    try:
-        yield
-    finally:
-        await store.close()
-
-
-app = FastAPI(lifespan=init_deps)
+app = FastAPI(lifespan=setup)
 
 app.include_router(oidc.router)
 app.include_router(manual.router)

--- a/noauth/main.py
+++ b/noauth/main.py
@@ -1,7 +1,7 @@
 """NoAuth."""
 
 import logging
-from os import getenv
+import logging.config
 
 from fastapi import FastAPI
 from fastapi.staticfiles import StaticFiles
@@ -11,10 +11,38 @@ from noauth.dependencies import setup
 from noauth import oidc
 from noauth import manual
 
-ACAPY = getenv("ACAPY", "http://localhost:3001")
 
-logging.getLogger("uvicorn.error").setLevel(logging.DEBUG)
-
+LOG_LEVEL = logging.DEBUG
+logging.config.dictConfig(
+    {
+        "version": 1,
+        "disable_existing_loggers": True,
+        "formatters": {
+            "standard": {
+                "format": "[%(asctime)s] %(levelname)s %(name)s: %(message)s",
+            },
+        },
+        "handlers": {
+            "default": {
+                "class": "logging.StreamHandler",
+                "formatter": "standard",
+                "stream": "ext://sys.stdout",
+            },
+        },
+        "loggers": {
+            "noauth": {
+                "handlers": ["default"],
+                "level": LOG_LEVEL,
+                "propagate": True,
+            },
+            "uvicorn": {
+                "handlers": ["default"],
+                "level": LOG_LEVEL,
+                "propagate": True,
+            },
+        },
+    }
+)
 
 app = FastAPI(lifespan=setup)
 

--- a/noauth/manual.py
+++ b/noauth/manual.py
@@ -14,7 +14,7 @@ from noauth import jwt
 from noauth.config import NoAuthConfig
 from noauth.oidc import url_with_query
 from noauth.templates import templates
-from noauth.dependencies import Config, Store, get, default_token
+from noauth.dependencies import config, default_token, store
 
 router = APIRouter(prefix="/manual")
 LOGGER = logging.getLogger("uvicorn.error." + __name__)
@@ -23,7 +23,7 @@ LOGGER = logging.getLogger("uvicorn.error." + __name__)
 @router.get("/token", response_class=HTMLResponse)
 async def manual_token(
     request: Request,
-    default_token: dict = Depends(get(default_token)),
+    default_token: dict = Depends(default_token),
 ):
     """Generate a token."""
     query = request.query_params
@@ -39,8 +39,8 @@ async def manual_token(
 async def post_manual_token_and_redirect(
     claims: str = Form(),
     valid_for: str = Form(),
-    store: AStore = Depends(get(Store)),
-    config: NoAuthConfig = Depends(get(Config)),
+    store: AStore = Depends(store),
+    config: NoAuthConfig = Depends(config),
 ):
     """Submit token form and get signed token."""
     try:

--- a/noauth/oidc.py
+++ b/noauth/oidc.py
@@ -15,7 +15,7 @@ from fastapi.responses import HTMLResponse, RedirectResponse
 from starlette.datastructures import UploadFile
 
 from noauth.config import NoAuthConfig
-from noauth.dependencies import Store, get, default_user, Config
+from noauth.dependencies import config, default_user, store
 from noauth.templates import templates
 from noauth import jwt
 
@@ -78,7 +78,7 @@ class OpenIDConfiguration:
 
 @router.get("/.well-known/openid-configuration")
 async def configuration(
-    config: NoAuthConfig = Depends(get(Config)),
+    config: NoAuthConfig = Depends(config),
 ):
     """Return openid-configuration."""
     return OpenIDConfiguration(
@@ -94,7 +94,7 @@ async def configuration(
 
 @router.get("/oidc/keys")
 async def keys(
-    store: AStore = Depends(get(Store)),
+    store: AStore = Depends(store),
 ):
     """Return keys."""
     async with store.session() as session:
@@ -116,8 +116,8 @@ async def authorize(
     redirect_uri: str = Query(),
     scope: str = Query(),
     state: str = Query(),
-    store: AStore = Depends(get(Store)),
-    default_user: dict = Depends(get(default_user)),
+    store: AStore = Depends(store),
+    default_user: dict = Depends(default_user),
 ):
     """OIDC Authorize endpoint."""
     if response_type != "code":
@@ -156,7 +156,7 @@ async def authorize(
 async def submit_and_redirect(
     id: str,
     claims: str = Form(),
-    store: AStore = Depends(get(Store)),
+    store: AStore = Depends(store),
 ):
     """Redirect back to the client."""
     try:
@@ -234,8 +234,8 @@ class TokenForm:
 @router.post("/oidc/token")
 async def token(
     request: Request,
-    store: AStore = Depends(get(Store)),
-    config: NoAuthConfig = Depends(get(Config)),
+    store: AStore = Depends(store),
+    config: NoAuthConfig = Depends(config),
 ):
     """OIDC Token endpoint."""
     form = TokenForm.validate(await request.form())

--- a/noauth/store.py
+++ b/noauth/store.py
@@ -89,7 +89,6 @@ class TemporalKVStore:
             expire_time = time.time() + ttl
             heapq.heappush(self.expiry_heap, (expire_time, key))
             self.new_expiry_event.set()
-            LOGGER.debug("heap status: %s", self.expiry_heap)
 
     async def get(self, key: str) -> Any:
         """Get a value."""

--- a/noauth/store.py
+++ b/noauth/store.py
@@ -1,0 +1,130 @@
+"""Temporal KV Store."""
+
+import asyncio
+import heapq
+import logging
+import time
+from typing import Any, Dict, List, Tuple
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+class TemporalKVStore:
+    """KV Store with TTL expiry."""
+
+    def __init__(self):
+        """Initialize the store."""
+        self.store: Dict[str, Any] = {}
+        self.expiry_heap: List[Tuple[float, str]] = []
+        self._lock: asyncio.Lock | None = None
+        self._expiry_task: asyncio.Task | None = None
+        self._new_expiry_event: asyncio.Event | None = None
+        self._ready_event: asyncio.Event | None = None
+
+    async def open(self):
+        """Open the store."""
+        self._lock = asyncio.Lock()
+        self._ready_event = asyncio.Event()
+        self._new_expiry_event = asyncio.Event()
+        self._expiry_task = asyncio.create_task(self._expiry_loop())
+        await self._ready_event.wait()
+        return self
+
+    @property
+    def lock(self) -> asyncio.Lock:
+        """Get lock."""
+        assert self._lock is not None, "Store is not open"
+        return self._lock
+
+    @property
+    def expiry_task(self) -> asyncio.Task:
+        """Get expiry task."""
+        assert self._expiry_task is not None, "Store is not open"
+        return self._expiry_task
+
+    @property
+    def new_expiry_event(self) -> asyncio.Event:
+        """Get new expiry event."""
+        assert self._new_expiry_event is not None, "Store is not open"
+        return self._new_expiry_event
+
+    async def _expiry_loop(self):
+        """Loop to handle expired tasks."""
+        assert self._ready_event
+        self._ready_event.set()
+        while True:
+            if not self.expiry_heap:
+                LOGGER.debug("No items, waiting until one is set")
+                await self.new_expiry_event.wait()
+
+            async with self.lock:
+                self.new_expiry_event.clear()
+                expire_time, key = self.expiry_heap[0]
+                now = time.time()
+                if now >= expire_time:
+                    LOGGER.debug("Expiring key: %s", key)
+                    heapq.heappop(self.expiry_heap)
+                    self.store.pop(key, None)
+                    continue
+                else:
+                    sleep_time = expire_time - now
+
+            LOGGER.debug("Sleep: wait for %s to expire or new item", key)
+            try:
+                await asyncio.wait_for(
+                    self.new_expiry_event.wait(),
+                    sleep_time,
+                )
+            except asyncio.TimeoutError:
+                LOGGER.debug("Awake: item ready to expire")
+            else:
+                LOGGER.debug("Awake: New item")
+
+    async def set(self, key: str, value: Any, ttl: float):
+        """Set a value."""
+        async with self.lock:
+            LOGGER.debug("Set: %s", key)
+            self.store[key] = value
+            expire_time = time.time() + ttl
+            heapq.heappush(self.expiry_heap, (expire_time, key))
+            self.new_expiry_event.set()
+            LOGGER.debug("heap status: %s", self.expiry_heap)
+
+    async def get(self, key: str) -> Any:
+        """Get a value."""
+        async with self.lock:
+            LOGGER.debug("Get: %s", key)
+            return self.store.get(key)
+
+    async def delete(self, key: str):
+        """Delete a value."""
+        async with self.lock:
+            LOGGER.debug("Delete: %s", key)
+            self.store.pop(key, None)
+            self.new_expiry_event.set()
+
+    async def close(self):
+        """Close the store."""
+        self.expiry_task.cancel()
+        try:
+            await self.expiry_task
+        except asyncio.CancelledError:
+            pass
+
+
+async def main():
+    """Example."""
+    kv = TemporalKVStore()
+    await kv.open()
+    await kv.set("key1", "value1", 5)  # key1 will expire in 5 seconds
+    await asyncio.sleep(1)
+    await kv.set("key2", "value2", 5)  # key1 will expire in 5 seconds
+    await asyncio.sleep(7)
+    print(kv.expiry_heap)  # Should print None as key1 has expired
+
+    await kv.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/noauth/templates/id_entry.html
+++ b/noauth/templates/id_entry.html
@@ -34,7 +34,7 @@
       const editor = new JSONEditor(container, options);
 
       // Set initial JSON
-      const initialJson = {{ default | tojson }};
+      const initialJson = {{ claims | tojson }};
       editor.set(initialJson);
 
       // Handle form submission


### PR DESCRIPTION
This PR introduces several major changes:

- No longer using Askar for persistence. Askar worked well enough but persistence is not necessary for this mock service. Askar is replaced by an in memory KV store that will automatically time out entries (statically set to 30 seconds for now).
  - This means that a passphrase config value is no longer required.
- No longer accept configuration by environment variable. The kind of configuration needed is more complex than environment variables can easily express. The only configuration path is no through the noauth.toml file.
- Specify client configuration in noauth.toml. It is now required to give client configuration for client_id, client_secret, and id_token_signed_response_alg. The client_id and secret are not yet enforced but may be in the future. See the next point for reasoning on the inclusion of id_token_signed_response_alg. See default.noauth.toml for an example.
- Using id_token_signed_response_alg client configuration option, dynamically determine the necessary key type. Only ES256 and EdDSA currently supported.
- Support custom scopes in noauth.toml. When the client includes one or more of these scopes in the auth request, the claims of the scope will be included in the resulting ID Token. Scopes are defined under `noauth.scopes` table. See default.noauth.toml for an example (`noauth.scopes.test`).
- Make sure an `access_token` is included in the token response. This token is unused for now but may be used in the future to implement a user info endpoint.

Partially address issues raised in #3.

I will look into the client_id/client_secret requirement and may update this PR or have a follow up PR.